### PR TITLE
Null check url on image load

### DIFF
--- a/app/src/main/java/tech/pauly/findapet/utils/BindingAdapters.java
+++ b/app/src/main/java/tech/pauly/findapet/utils/BindingAdapters.java
@@ -37,6 +37,9 @@ public class BindingAdapters {
 
     @BindingAdapter("imageUrl")
     public static void loadImageIntoView(ImageView view, String url) {
+        if (url == null) {
+            return;
+        }
         final Transformation transformation = new RoundedCornersTransformation(10, 0);
         Picasso.with(view.getContext())
                .load(Uri.parse(url))


### PR DESCRIPTION
Story: https://www.pivotaltracker.com/story/show/158264039

We set the view model to null when destroying pager items and so the binding adapters get called with null values. Just a simple check here to make sure that doesn't crash the app